### PR TITLE
Work around regression in IT copula with dask >= 1.1

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -8,6 +8,8 @@ What's New
 v0.2.0 (unreleased)
 -------------------
 
+- Work around regression in IT copula with dask >= 1.1
+  (`<https://github.com/dask/dask/issues/4739> dask#4739>`)
 - Explicit CI tests for Windows and Python 3.7
 - Mandatory flake8 in CI
 - Changed license to Apache 2.0


### PR DESCRIPTION
IT copula is broken on dask >= 1.1. See upstream issue: https://github.com/dask/dask/issues/4739